### PR TITLE
design: 페이지별 컴포넌트에 Layout 컴포넌트, 가이드 템플릿 적용

### DIFF
--- a/src/components/pages/Article.tsx
+++ b/src/components/pages/Article.tsx
@@ -1,10 +1,134 @@
 import Layout from '../layout/Layout';
 
 const Article = () => {
-  return;
-  <Layout>
-    <div>ㅎㅇ</div>;
-  </Layout>;
+  return (
+    <Layout>
+      <div className="article-page">
+        <div className="banner">
+          <div className="container">
+            <h1>How to build webapps that scale</h1>
+
+            <div className="article-meta">
+              <a href="">
+                <img src="http://i.imgur.com/Qr71crq.jpg" />
+              </a>
+              <div className="info">
+                <a href="" className="author">
+                  Eric Simons
+                </a>
+                <span className="date">January 20th</span>
+              </div>
+              <button className="btn btn-sm btn-outline-secondary">
+                <i className="ion-plus-round"></i>
+                &nbsp; Follow Eric Simons <span className="counter">(10)</span>
+              </button>
+              &nbsp;&nbsp;
+              <button className="btn btn-sm btn-outline-primary">
+                <i className="ion-heart"></i>
+                &nbsp; Favorite Post <span className="counter">(29)</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="container page">
+          <div className="row article-content">
+            <div className="col-md-12">
+              <p>
+                Web development technologies have evolved at an incredible clip over the past few
+                years.
+              </p>
+              <h2 id="introducing-ionic">Introducing RealWorld.</h2>
+              <p>It's a great solution for learning how other frameworks work.</p>
+            </div>
+          </div>
+
+          <hr />
+
+          <div className="article-actions">
+            <div className="article-meta">
+              <a href="profile.html">
+                <img src="http://i.imgur.com/Qr71crq.jpg" />
+              </a>
+              <div className="info">
+                <a href="" className="author">
+                  Eric Simons
+                </a>
+                <span className="date">January 20th</span>
+              </div>
+              <button className="btn btn-sm btn-outline-secondary">
+                <i className="ion-plus-round"></i>
+                &nbsp; Follow Eric Simons
+              </button>
+              &nbsp;
+              <button className="btn btn-sm btn-outline-primary">
+                <i className="ion-heart"></i>
+                &nbsp; Favorite Post <span className="counter">(29)</span>
+              </button>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="col-xs-12 col-md-8 offset-md-2">
+              <form className="card comment-form">
+                <div className="card-block">
+                  <textarea
+                    className="form-control"
+                    placeholder="Write a comment..."
+                    rows={3}
+                  ></textarea>
+                </div>
+                <div className="card-footer">
+                  <img src="http://i.imgur.com/Qr71crq.jpg" className="comment-author-img" />
+                  <button className="btn btn-sm btn-primary">Post Comment</button>
+                </div>
+              </form>
+
+              <div className="card">
+                <div className="card-block">
+                  <p className="card-text">
+                    With supporting text below as a natural lead-in to additional content.
+                  </p>
+                </div>
+                <div className="card-footer">
+                  <a href="" className="comment-author">
+                    <img src="http://i.imgur.com/Qr71crq.jpg" className="comment-author-img" />
+                  </a>
+                  &nbsp;
+                  <a href="" className="comment-author">
+                    Jacob Schmidt
+                  </a>
+                  <span className="date-posted">Dec 29th</span>
+                </div>
+              </div>
+
+              <div className="card">
+                <div className="card-block">
+                  <p className="card-text">
+                    With supporting text below as a natural lead-in to additional content.
+                  </p>
+                </div>
+                <div className="card-footer">
+                  <a href="" className="comment-author">
+                    <img src="http://i.imgur.com/Qr71crq.jpg" className="comment-author-img" />
+                  </a>
+                  &nbsp;
+                  <a href="" className="comment-author">
+                    Jacob Schmidt
+                  </a>
+                  <span className="date-posted">Dec 29th</span>
+                  <span className="mod-options">
+                    <i className="ion-edit"></i>
+                    <i className="ion-trash-a"></i>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
 };
 
 export default Article;

--- a/src/components/pages/Article.tsx
+++ b/src/components/pages/Article.tsx
@@ -1,5 +1,10 @@
+import Layout from '../layout/Layout';
+
 const Article = () => {
-  return <div>ㅎㅇ</div>;
+  return;
+  <Layout>
+    <div>ㅎㅇ</div>;
+  </Layout>;
 };
 
 export default Article;

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -1,5 +1,10 @@
+import Layout from '../layout/Layout';
+
 const CreateArticle = () => {
-  return <div>ㅎㅇ</div>;
+  return;
+  <Layout>
+    <div>ㅎㅇ</div>;
+  </Layout>;
 };
 
 export default CreateArticle;

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -1,10 +1,50 @@
 import Layout from '../layout/Layout';
 
 const CreateArticle = () => {
-  return;
-  <Layout>
-    <div>ㅎㅇ</div>;
-  </Layout>;
+  return (
+    <Layout>
+      <div className="editor-page">
+        <div className="container page">
+          <div className="row">
+            <div className="col-md-10 offset-md-1 col-xs-12">
+              <form>
+                <fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      type="text"
+                      className="form-control form-control-lg"
+                      placeholder="Article Title"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      type="text"
+                      className="form-control"
+                      placeholder="What's this article about?"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <textarea
+                      className="form-control"
+                      rows={8}
+                      placeholder="Write your article (in markdown)"
+                    ></textarea>
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input type="text" className="form-control" placeholder="Enter tags" />
+                    <div className="tag-list"></div>
+                  </fieldset>
+                  <button className="btn btn-lg pull-xs-right btn-primary" type="button">
+                    Publish Article
+                  </button>
+                </fieldset>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
 };
 
 export default CreateArticle;

--- a/src/components/pages/EditArticle.tsx
+++ b/src/components/pages/EditArticle.tsx
@@ -1,10 +1,50 @@
 import Layout from '../layout/Layout';
 
 const EditArticle = () => {
-  return;
-  <Layout>
-    <div>ㅎㅇ</div>;
-  </Layout>;
+  return (
+    <Layout>
+      <div className="editor-page">
+        <div className="container page">
+          <div className="row">
+            <div className="col-md-10 offset-md-1 col-xs-12">
+              <form>
+                <fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      type="text"
+                      className="form-control form-control-lg"
+                      placeholder="Article Title"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      type="text"
+                      className="form-control"
+                      placeholder="What's this article about?"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <textarea
+                      className="form-control"
+                      rows={8}
+                      placeholder="Write your article (in markdown)"
+                    ></textarea>
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input type="text" className="form-control" placeholder="Enter tags" />
+                    <div className="tag-list"></div>
+                  </fieldset>
+                  <button className="btn btn-lg pull-xs-right btn-primary" type="button">
+                    Publish Article
+                  </button>
+                </fieldset>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
 };
 
 export default EditArticle;

--- a/src/components/pages/EditArticle.tsx
+++ b/src/components/pages/EditArticle.tsx
@@ -1,5 +1,10 @@
+import Layout from '../layout/Layout';
+
 const EditArticle = () => {
-  return <div>ㅎㅇ</div>;
+  return;
+  <Layout>
+    <div>ㅎㅇ</div>;
+  </Layout>;
 };
 
 export default EditArticle;

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -3,7 +3,112 @@ import Layout from '../layout/Layout';
 const Home = () => {
   return (
     <Layout>
-      <div>ㅎㅇ</div>
+      <div className="home-page">
+        <div className="banner">
+          <div className="container">
+            <h1 className="logo-font">conduit</h1>
+            <p>A place to share your knowledge.</p>
+          </div>
+        </div>
+
+        <div className="container page">
+          <div className="row">
+            <div className="col-md-9">
+              <div className="feed-toggle">
+                <ul className="nav nav-pills outline-active">
+                  <li className="nav-item">
+                    <a className="nav-link disabled" href="">
+                      Your Feed
+                    </a>
+                  </li>
+                  <li className="nav-item">
+                    <a className="nav-link active" href="">
+                      Global Feed
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="article-preview">
+                <div className="article-meta">
+                  <a href="profile.html">
+                    <img src="http://i.imgur.com/Qr71crq.jpg" />
+                  </a>
+                  <div className="info">
+                    <a href="" className="author">
+                      Eric Simons
+                    </a>
+                    <span className="date">January 20th</span>
+                  </div>
+                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                    <i className="ion-heart"></i> 29
+                  </button>
+                </div>
+                <a href="" className="preview-link">
+                  <h1>How to build webapps that scale</h1>
+                  <p>This is the description for the post.</p>
+                  <span>Read more...</span>
+                </a>
+              </div>
+
+              <div className="article-preview">
+                <div className="article-meta">
+                  <a href="profile.html">
+                    <img src="http://i.imgur.com/N4VcUeJ.jpg" />
+                  </a>
+                  <div className="info">
+                    <a href="" className="author">
+                      Albert Pai
+                    </a>
+                    <span className="date">January 20th</span>
+                  </div>
+                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                    <i className="ion-heart"></i> 32
+                  </button>
+                </div>
+                <a href="" className="preview-link">
+                  <h1>The song you won't ever stop singing. No matter how hard you try.</h1>
+                  <p>This is the description for the post.</p>
+                  <span>Read more...</span>
+                </a>
+              </div>
+            </div>
+
+            <div className="col-md-3">
+              <div className="sidebar">
+                <p>Popular Tags</p>
+
+                <div className="tag-list">
+                  <a href="" className="tag-pill tag-default">
+                    programming
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    javascript
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    emberjs
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    angularjs
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    react
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    mean
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    node
+                  </a>
+                  <a href="" className="tag-pill tag-default">
+                    rails
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 };

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -1,5 +1,11 @@
+import Layout from '../layout/Layout';
+
 const Home = () => {
-  return <div>ㅎㅇ</div>;
+  return (
+    <Layout>
+      <div>ㅎㅇ</div>
+    </Layout>
+  );
 };
 
 export default Home;

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -1,5 +1,11 @@
+import Layout from '../layout/Layout';
+
 const Profile = () => {
-  return <div>ㅎㅇ</div>;
+  return (
+    <Layout>
+      <div>ㅎㅇ</div>
+    </Layout>
+  );
 };
 
 export default Profile;

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -3,7 +3,95 @@ import Layout from '../layout/Layout';
 const Profile = () => {
   return (
     <Layout>
-      <div>ㅎㅇ</div>
+      <div className="profile-page">
+        <div className="user-info">
+          <div className="container">
+            <div className="row">
+              <div className="col-xs-12 col-md-10 offset-md-1">
+                <img src="http://i.imgur.com/Qr71crq.jpg" className="user-img" />
+                <h4>Eric Simons</h4>
+                <p>
+                  Cofounder @GoThinkster, lived in Aol's HQ for a few months, kinda looks like Peeta
+                  from the Hunger Games
+                </p>
+                <button className="btn btn-sm btn-outline-secondary action-btn">
+                  <i className="ion-plus-round"></i>
+                  &nbsp; Follow Eric Simons
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="container">
+          <div className="row">
+            <div className="col-xs-12 col-md-10 offset-md-1">
+              <div className="articles-toggle">
+                <ul className="nav nav-pills outline-active">
+                  <li className="nav-item">
+                    <a className="nav-link active" href="">
+                      My Articles
+                    </a>
+                  </li>
+                  <li className="nav-item">
+                    <a className="nav-link" href="">
+                      Favorited Articles
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="article-preview">
+                <div className="article-meta">
+                  <a href="">
+                    <img src="http://i.imgur.com/Qr71crq.jpg" />
+                  </a>
+                  <div className="info">
+                    <a href="" className="author">
+                      Eric Simons
+                    </a>
+                    <span className="date">January 20th</span>
+                  </div>
+                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                    <i className="ion-heart"></i> 29
+                  </button>
+                </div>
+                <a href="" className="preview-link">
+                  <h1>How to build webapps that scale</h1>
+                  <p>This is the description for the post.</p>
+                  <span>Read more...</span>
+                </a>
+              </div>
+
+              <div className="article-preview">
+                <div className="article-meta">
+                  <a href="">
+                    <img src="http://i.imgur.com/N4VcUeJ.jpg" />
+                  </a>
+                  <div className="info">
+                    <a href="" className="author">
+                      Albert Pai
+                    </a>
+                    <span className="date">January 20th</span>
+                  </div>
+                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                    <i className="ion-heart"></i> 32
+                  </button>
+                </div>
+                <a href="" className="preview-link">
+                  <h1>The song you won't ever stop singing. No matter how hard you try.</h1>
+                  <p>This is the description for the post.</p>
+                  <span>Read more...</span>
+                  <ul className="tag-list">
+                    <li className="tag-default tag-pill tag-outline">Music</li>
+                    <li className="tag-default tag-pill tag-outline">Song</li>
+                  </ul>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 };

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -1,5 +1,11 @@
+import Layout from '../layout/Layout';
+
 const Settings = () => {
-  return <div>ㅎㅇ</div>;
+  return (
+    <Layout>
+      <div>ㅎㅇ</div>
+    </Layout>
+  );
 };
 
 export default Settings;

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -3,7 +3,58 @@ import Layout from '../layout/Layout';
 const Settings = () => {
   return (
     <Layout>
-      <div>ㅎㅇ</div>
+      <div className="settings-page">
+        <div className="container page">
+          <div className="row">
+            <div className="col-md-6 offset-md-3 col-xs-12">
+              <h1 className="text-xs-center">Your Settings</h1>
+
+              <form>
+                <fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      className="form-control"
+                      type="text"
+                      placeholder="URL of profile picture"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      className="form-control form-control-lg"
+                      type="text"
+                      placeholder="Your Name"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <textarea
+                      className="form-control form-control-lg"
+                      rows={8}
+                      placeholder="Short bio about you"
+                    ></textarea>
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      className="form-control form-control-lg"
+                      type="text"
+                      placeholder="Email"
+                    />
+                  </fieldset>
+                  <fieldset className="form-group">
+                    <input
+                      className="form-control form-control-lg"
+                      type="password"
+                      placeholder="Password"
+                    />
+                  </fieldset>
+                  <button className="btn btn-lg btn-primary pull-xs-right">Update Settings</button>
+                </fieldset>
+              </form>
+              <hr />
+              <button className="btn btn-outline-danger">Or click here to logout.</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 };


### PR DESCRIPTION
## 작업 내용
- 페이지마다 Layout 컴포넌트로 감쌌습니다 (Header/Footer 넣는 용)

- 페이지별 템플릿을 넣었습니다. [참고 링크](https://realworld-docs.netlify.app/docs/specs/frontend-specs/templates/#article)

## 실행 화면
추가 예정