### PR TITLE
feat(Header): 로그인 여부에 따른 메뉴 변경

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,20 @@
+import { useRecoilState } from 'recoil';
+import { currentUserState } from '../../recoil/atom/currentUserData';
+
 const Header = () => {
-  const headerMenu = ['Home', 'New Post', 'Settings', 'Sign Up', 'Sign In'];
+  const [user, setUser] = useRecoilState(currentUserState);
+
+  const logout = () => {
+    setUser({
+      user: {
+        username: '',
+        email: '',
+        token: '',
+        bio: '',
+        image: '',
+      },
+    });
+  };
 
   return (
     <>
@@ -9,19 +24,49 @@ const Header = () => {
             conduit
           </a>
           <ul className="nav navbar-nav pull-xs-right">
-            {headerMenu.map((headerMenuData, index) => (
-              <li
-                className="nav-item"
-                key={index}
-                onClick={() => {
-                  alert(headerMenuData);
-                }}
-              >
-                <a className="nav-link" href="">
-                  <i className="ion-compose"></i>&nbsp;{headerMenuData}{' '}
-                </a>
-              </li>
-            ))}
+            <li className="nav-item">
+              <a className="nav-link active" href="">
+                Home
+              </a>
+            </li>
+            {user.token !== '' ? (
+              <>
+                <li className="nav-item">
+                  <a className="nav-link" href="/#/editor">
+                    <i className="ion-compose"></i>&nbsp;New Article
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a className="nav-link" href="/#/settings">
+                    <i className="ion-gear-a"></i>&nbsp;Settings
+                  </a>
+                </li>
+                <li className="nav-item" onClick={logout}>
+                  <a className="nav-link" href="">
+                    <img className="user-pic" src={user.image} ng-src={user.image} />
+                    &nbsp;{user.username}
+                  </a>
+                </li>
+                <li className="nav-item" onClick={logout}>
+                  <a className="nav-link" href="">
+                    <i className="ion-gear-a"></i>&nbsp;Log out
+                  </a>
+                </li>
+              </>
+            ) : (
+              <>
+                <li className="nav-item">
+                  <a className="nav-link" href="/#/login">
+                    Sign in
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a className="nav-link" href="/#/register">
+                    Sign up
+                  </a>
+                </li>
+              </>
+            )}
           </ul>
         </div>
       </nav>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ const Header = () => {
                 Home
               </a>
             </li>
-            {user.token !== '' ? (
+            {user.user.token !== '' ? (
               <>
                 <li className="nav-item">
                   <a className="nav-link" href="/#/editor">
@@ -43,8 +43,8 @@ const Header = () => {
                 </li>
                 <li className="nav-item" onClick={logout}>
                   <a className="nav-link" href="">
-                    <img className="user-pic" src={user.image} ng-src={user.image} />
-                    &nbsp;{user.username}
+                    <img className="user-pic" src={user.user.image} ng-src={user.user.image} />
+                    &nbsp;{user.user.username}
                   </a>
                 </li>
                 <li className="nav-item" onClick={logout}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -49,7 +49,7 @@ const Header = () => {
                 </li>
                 <li className="nav-item" onClick={logout}>
                   <a className="nav-link" href="">
-                    <i className="ion-gear-a"></i>&nbsp;Log out
+                    Log out
                   </a>
                 </li>
               </>

--- a/src/components/pages/Signin.tsx
+++ b/src/components/pages/Signin.tsx
@@ -55,7 +55,7 @@ const Signin = () => {
   };
 
   useEffect(() => {
-    if (signinResponseData.token !== '') {
+    if (signinResponseData.user.token !== '') {
       navigate('/');
     }
   }, [signinResponseData]);

--- a/src/recoil/atom/currentUserData.ts
+++ b/src/recoil/atom/currentUserData.ts
@@ -7,11 +7,13 @@ const { persistAtom } = recoilPersist();
 export const currentUserState = atom<IGlobalUserData>({
   key: 'currentUserState',
   default: {
-    username: '',
-    email: '',
-    token: '',
-    bio: '',
-    image: '',
+    user: {
+      username: '',
+      email: '',
+      token: '',
+      bio: '',
+      image: '',
+    },
   },
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/types/userApi.type.ts
+++ b/src/types/userApi.type.ts
@@ -34,9 +34,5 @@ export interface IEditUserData {
  * @ACTION globalData
  */
 export interface IGlobalUserData {
-  username: string;
-  email: string;
-  token: string;
-  bio: string;
-  image: string;
+  user: { username: string; email: string; token: string; bio: string; image: string };
 }


### PR DESCRIPTION
## 작업 내용

- https://github.com/nijuy/realworld-PB/pull/4/commits/c99350a018df34fca9602f547992c722046732ba : api 응답과 동일한 형태로 타입을 정의하기 위해, `IGlobalUserData` 타입을 수정했습니다 <br/>

  |수정 전|api 응답|수정 후|
  |---|---|---|
  |![image](https://github.com/nijuy/realworld-PB/assets/87255462/4b964eac-7772-424f-a2d3-92bb6f5f6e90)|![image](https://github.com/nijuy/realworld-PB/assets/87255462/a8c6b896-792d-4f64-bcb8-5e5a4fc60a2d)|![image](https://github.com/nijuy/realworld-PB/assets/87255462/04910906-7209-40c5-965f-a92557f98e02)|
  |user 객체로 감싸지 않음||user 객체로 감쌈|

  - `IGlobalUserData`를 사용하던 코드를 수정했습니다.

- Header 메뉴 불러오는 방식을 변경했습니다.

  - 이전 : 메뉴 배열을 `map()`으로 뿌림
  - 현재 : 모든 메뉴를 html 로 작성해놓고, 노출 여부만 로그인 여부에 따라 나눔

- Log out 메뉴를 추가했습니다.

  - 데모에서는 Settings에서만 로그아웃이 가능한데 그게 너무 귀찮아서 메뉴를 하나 늘렸습니다!
  
- 로그인 여부에 따라 보이는 메뉴가 달라집니다

  - 로그인 ⭕ : Home, New Article, Settings, Profile, Log out
  - 로그인 ❌ : Home, Sign in, Sign up

## 기타
@indianaPoly 

* https://github.com/nijuy/realworld-PB/pull/4/commits/29fdd6d6c9d3088d612a5056a705180f9b1dbc86 : Header.tsx 에서 노출할 메뉴를 정할 때, user info에 접근하는 방식을 변경했습니다 (`user.token` ➡ `user.user.token`) 

    - 이전 방식으로 했을 때 정상적으로 작동하지 않습니다!<br/>금요일에 제대로 됐던 건 `recoil-persist`때문에 스토리지에 값이 남아있어서 그랬던거 같아요... 🤔

* ~~Log out 메뉴 아이콘을 변경해야 합니다 (지금은 Settings 아이콘과 동일함) 근데 그냥 아이콘 삭제가 깔꼼할듯!~~ ➡ 커밋 https://github.com/nijuy/realworld-PB/pull/4/commits/404e4d1bb6af5757db2b467ce20ca9588864cc6a 에서 삭제 끝~

## 실행 화면
![test](https://github.com/nijuy/realworld-PB/assets/87255462/25d7c8f5-21c5-4259-9ea1-70b0d8144570)

