### PR TITLE
feat(join): 회원 가입 기능 추가

### DIFF
--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -72,7 +72,7 @@ const Signup = () => {
               <div className="col-md-6 offset-md-3 col-xs-12">
                 <h1 className="text-xs-center">Sign Up</h1>
                 <p className="text-xs-center">
-                  <a href="">Have an account?</a>
+                  <a href="#/login">Have an account?</a>
                 </p>
 
                 {signupStatusData && !signupStatusData.signupStatus && (

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -1,64 +1,67 @@
 import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { currentUserState } from '../../recoil/atom/currentUserData';
+import { IJoinUserData, IGlobalUserData } from '../../types/userApi.type';
+import { AxiosError } from 'axios';
+import { IError } from '../../types/error.type';
 import Layout from '../layout/Layout';
 import userApi from '../../api/userApi';
-import { IJoinUserData } from '../../types/userApi.type';
+import ErrorPrint from '../ErrorPrint';
+
+interface ISignupError extends IError {
+  signupStatus: boolean;
+}
 
 const Signup = () => {
-  const [signupData, setSignupData] = useState<IJoinUserData>();
+  let signupData: IJoinUserData = {
+    email: '',
+    password: '',
+    username: '',
+  };
+  const [signupResponseData, setSignupResponseData] =
+    useRecoilState<IGlobalUserData>(currentUserState);
+  const [signupStatusData, setSignupStatusData] = useState<ISignupError>();
 
   const emailRef = useRef<HTMLInputElement>(null);
-  const nicknameRef = useRef<HTMLInputElement>(null);
+  const usernameRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
 
-  const onChangeSignupData = (formEvent: React.FormEvent<HTMLInputElement>) => {
-    switch (formEvent.currentTarget.value) {
-      case 'email':
-        break;
-      case 'nickname':
-        break;
-      case 'password':
-        break;
-    }
-  };
+  const navigate = useNavigate();
 
   const onClickSignupData = (buttonEvent: React.MouseEvent<HTMLButtonElement>) => {
     buttonEvent.preventDefault();
-    if (emailRef.current !== null && nicknameRef.current !== null && passwordRef.current !== null) {
-      if (
-        emailRef.current.value === '' ||
-        nicknameRef.current.value === '' ||
-        passwordRef.current.value === ''
-      ) {
-        alert('!');
-      }
-      setSignupData({
+    if (emailRef.current !== null && usernameRef.current !== null && passwordRef.current !== null) {
+      signupData = {
         email: emailRef.current.value,
-        username: nicknameRef.current.value,
+        username: usernameRef.current.value,
         password: passwordRef.current.value,
-      });
+      };
+      join(signupData);
+    }
+  };
+
+  const join = async (signupData: IJoinUserData) => {
+    try {
+      const response = await userApi.join({ user: signupData });
+      setSignupResponseData(response.data);
+    } catch (error) {
+      const signupError = error as AxiosError;
+      if (signupError.response !== undefined && signupError.response.data !== null) {
+        const response = signupError.response.data as IError;
+        setSignupStatusData({
+          signupStatus: false,
+          errors: response.errors,
+        });
+      }
     }
   };
 
   useEffect(() => {
-    setSignupData({
-      email: '',
-      username: '',
-      password: '',
-    });
-
-    const test = {
-      username: 'indianapoylylyl',
-      email: 'hyeonlimgo5@gmail.com',
-      password: 'tiehdn1300',
-    };
-
-    const test2 = userApi.join({ user: test });
-    console.log(test2);
-  }, []);
-
-  useEffect(() => {
-    console.log(signupData?.email);
-  }, [signupData]);
+    if (signupResponseData.token !== '') {
+      navigate('/');
+    }
+  }, [signupResponseData]);
 
   return (
     <>
@@ -72,14 +75,20 @@ const Signup = () => {
                   <a href="">Have an account?</a>
                 </p>
 
+                {signupStatusData && !signupStatusData.signupStatus && (
+                  <ul className="error-messages">
+                    <ErrorPrint errors={signupStatusData.errors} />
+                  </ul>
+                )}
+
                 <form>
                   <fieldset className="form-group">
                     <fieldset className="form-group">
                       <input
                         className="form-control form-control-lg"
-                        type="password"
-                        placeholder="Password"
-                        ref={nicknameRef}
+                        type="text"
+                        placeholder="Username"
+                        ref={usernameRef}
                       />
                     </fieldset>
                     <input


### PR DESCRIPTION
## 작업 내용

- 회원 가입 기능을 추가했습니다.

  - 변수명 응답 속성명과 동일하게 변경 (`nickname` ➡ `username`)

  - 안 쓰는 함수(`onChangeSignupData`), 테스트 데이터(`test`) 삭제 

  - 가이드 템플릿 적용 시 잘못 썼던 부분 수정 (password 입력칸이 2개였음)

  - 에러 처리 방식 변경

    - 이전: 공란이면 `alert("!")`

    - 현재: 클라이언트에서 체크 ❌ ErrorPrint 컴포넌트로 서버에서 준 에러 출력

      https://github.com/nijuy/realworld-PB/issues/1

- `onClickSignupData()`, `join()`은 로그인 기능과 비슷하게 작동해서 설명 작성하지 않음

## 기타
- ~~"Have an account?" 글자에 href 걸어야 합니다~~ ➡ 커밋 https://github.com/nijuy/realworld-PB/pull/6/commits/09fa58e12af6a17f5d86f581a7e50dfab443730b 에서 수정 완료~

## 실행 화면
(1) 공란일 때 에러 메시지 출력
(2) 이미 가입된 이메일일 때 에러 메시지 출력
(3) 이미 존재하는 `username`일 때 에러 메시지 출력
(4) 가입 후 홈 화면 이동

![test](https://github.com/nijuy/realworld-PB/assets/87255462/a4167192-b356-4f69-953e-d007c1921c27)


