### PR TITLE
feat(Setting): 세팅 페이지 

### DIFF
--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -12,16 +12,8 @@ const userApi = {
     const response = Axios.get<IGlobalUserData>('/user');
     return response;
   },
-  modify: () => {
-    const response = Axios.put<IEditUserData>('/user', {
-      user: {
-        email: 'string',
-        password: 'string',
-        username: 'string',
-        bio: 'string',
-        image: 'string',
-      },
-    });
+  modify: (userData: { user: IEditUserData }): Promise<AxiosResponse<IGlobalUserData>> => {
+    const response = Axios.put('/user', userData);
     return response;
   },
 

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -1,9 +1,26 @@
 import Layout from '../layout/Layout';
 import { useRecoilState } from 'recoil';
 import { currentUserState } from '../../recoil/atom/currentUserData';
+import { useNavigate } from 'react-router-dom';
 
 const Settings = () => {
-  const [user] = useRecoilState(currentUserState);
+  const [user, setUser] = useRecoilState(currentUserState);
+
+  const navigate = useNavigate();
+
+  const logout = () => {
+    setUser({
+      user: {
+        username: '',
+        email: '',
+        token: '',
+        bio: '',
+        image: '',
+      },
+    });
+
+    navigate('/');
+  };
 
   return (
     <Layout>
@@ -58,7 +75,9 @@ const Settings = () => {
                 </fieldset>
               </form>
               <hr />
-              <button className="btn btn-outline-danger">Or click here to logout.</button>
+              <button className="btn btn-outline-danger" onClick={logout}>
+                Or click here to logout.
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -2,12 +2,18 @@ import Layout from '../layout/Layout';
 import { useRecoilState } from 'recoil';
 import { currentUserState } from '../../recoil/atom/currentUserData';
 import { useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const Settings = () => {
   const [user, setUser] = useRecoilState(currentUserState);
 
   const navigate = useNavigate();
+
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const imageRef = useRef<HTMLInputElement>(null);
+  const bioRef = useRef<HTMLTextAreaElement>(null);
+  const usernameRef = useRef<HTMLInputElement>(null);
 
   const logout = () => {
     setUser({
@@ -45,6 +51,7 @@ const Settings = () => {
                       type="text"
                       placeholder="URL of profile picture"
                       defaultValue={user.user.image}
+                      ref={imageRef}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -53,6 +60,7 @@ const Settings = () => {
                       type="text"
                       placeholder="Your Name"
                       defaultValue={user.user.username}
+                      ref={usernameRef}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -61,6 +69,7 @@ const Settings = () => {
                       rows={8}
                       placeholder="Short bio about you"
                       defaultValue={user.user.bio}
+                      ref={bioRef}
                     ></textarea>
                   </fieldset>
                   <fieldset className="form-group">
@@ -69,6 +78,7 @@ const Settings = () => {
                       type="email"
                       placeholder="Email"
                       defaultValue={user.user.email}
+                      ref={emailRef}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -77,6 +87,7 @@ const Settings = () => {
                       type="password"
                       placeholder="Password"
                       autoComplete="new-password"
+                      ref={passwordRef}
                     />
                   </fieldset>
                   <button className="btn btn-lg btn-primary pull-xs-right">Update Settings</button>

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -60,6 +60,7 @@ const Settings = () => {
                       className="form-control form-control-lg"
                       rows={8}
                       placeholder="Short bio about you"
+                      defaultValue={user.user.bio}
                     ></textarea>
                   </fieldset>
                   <fieldset className="form-group">

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -5,6 +5,8 @@ import { useNavigate } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import userApi from '../../api/userApi';
 import { IEditUserData } from '../../types/userApi.type';
+import { setToken } from '../../services/TokenService';
+import { updateHeader } from '../../api/api';
 
 const Settings = () => {
   const [user, setUser] = useRecoilState(currentUserState);
@@ -50,7 +52,8 @@ const Settings = () => {
     try {
       const response = await userApi.modify({ user: userData });
       setUser(response.data);
-      //토큰 갱신 코드 추가 예정
+      setToken(user.user.token);
+      updateHeader(user.user.token);
     } catch (error) {
       console.log(error);
     }

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -35,8 +35,9 @@ const Settings = () => {
     navigate('/');
   };
 
-  const onSubmitUserData = () => {
+  const onSubmitUserData = (buttonEvent: React.MouseEvent<HTMLButtonElement>) => {
     if (emailRef.current?.checkValidity()) {
+      buttonEvent.preventDefault();
       userData = {
         username: usernameRef.current!.value,
         email: emailRef.current.value,
@@ -52,8 +53,9 @@ const Settings = () => {
     try {
       const response = await userApi.modify({ user: userData });
       setUser(response.data);
-      setToken(user.user.token);
-      updateHeader(user.user.token);
+      setToken(response.data.user.token);
+      updateHeader(response.data.user.token);
+      navigate('/'); // profile page로 수정 필요
     } catch (error) {
       console.log(error);
     }

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -66,7 +66,7 @@ const Settings = () => {
                   <fieldset className="form-group">
                     <input
                       className="form-control form-control-lg"
-                      type="text"
+                      type="email"
                       placeholder="Email"
                       defaultValue={user.user.email}
                     />

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -3,9 +3,13 @@ import { useRecoilState } from 'recoil';
 import { currentUserState } from '../../recoil/atom/currentUserData';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
+import userApi from '../../api/userApi';
+import { IEditUserData } from '../../types/userApi.type';
 
 const Settings = () => {
   const [user, setUser] = useRecoilState(currentUserState);
+
+  let userData: IEditUserData = { username: '', email: '', password: '', bio: '', image: '' };
 
   const navigate = useNavigate();
 
@@ -27,6 +31,29 @@ const Settings = () => {
     });
 
     navigate('/');
+  };
+
+  const onSubmitUserData = () => {
+    if (emailRef.current?.checkValidity()) {
+      userData = {
+        username: usernameRef.current!.value,
+        email: emailRef.current.value,
+        password: passwordRef.current!.value,
+        bio: bioRef.current!.value,
+        image: imageRef.current!.value,
+      };
+      update(userData);
+    }
+  };
+
+  const update = async (userData: IEditUserData) => {
+    try {
+      const response = await userApi.modify({ user: userData });
+      setUser(response.data);
+      //토큰 갱신 코드 추가 예정
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   useEffect(() => {
@@ -90,7 +117,12 @@ const Settings = () => {
                       ref={passwordRef}
                     />
                   </fieldset>
-                  <button className="btn btn-lg btn-primary pull-xs-right">Update Settings</button>
+                  <button
+                    className="btn btn-lg btn-primary pull-xs-right"
+                    onClick={onSubmitUserData}
+                  >
+                    Update Settings
+                  </button>
                 </fieldset>
               </form>
               <hr />

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -55,7 +55,7 @@ const Settings = () => {
       setUser(response.data);
       setToken(response.data.user.token);
       updateHeader(response.data.user.token);
-      navigate('/'); // profile page로 수정 필요
+      navigate(`/profile/${response.data.user.username}`);
     } catch (error) {
       console.log(error);
     }

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import userApi from '../../api/userApi';
 import { IEditUserData } from '../../types/userApi.type';
-import { setToken } from '../../services/TokenService';
+import { removeItemToken, setToken } from '../../services/TokenService';
 import { updateHeader } from '../../api/api';
 
 const Settings = () => {
@@ -31,7 +31,7 @@ const Settings = () => {
         image: '',
       },
     });
-
+    removeItemToken();
     navigate('/');
   };
 

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -2,6 +2,7 @@ import Layout from '../layout/Layout';
 import { useRecoilState } from 'recoil';
 import { currentUserState } from '../../recoil/atom/currentUserData';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 const Settings = () => {
   const [user, setUser] = useRecoilState(currentUserState);
@@ -21,6 +22,12 @@ const Settings = () => {
 
     navigate('/');
   };
+
+  useEffect(() => {
+    if (user.user.token === '') {
+      navigate('/');
+    }
+  }, []);
 
   return (
     <Layout>

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -1,6 +1,10 @@
 import Layout from '../layout/Layout';
+import { useRecoilState } from 'recoil';
+import { currentUserState } from '../../recoil/atom/currentUserData';
 
 const Settings = () => {
+  const [user] = useRecoilState(currentUserState);
+
   return (
     <Layout>
       <div className="settings-page">
@@ -16,6 +20,7 @@ const Settings = () => {
                       className="form-control"
                       type="text"
                       placeholder="URL of profile picture"
+                      defaultValue={user.user.image}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -23,6 +28,7 @@ const Settings = () => {
                       className="form-control form-control-lg"
                       type="text"
                       placeholder="Your Name"
+                      defaultValue={user.user.username}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -37,6 +43,7 @@ const Settings = () => {
                       className="form-control form-control-lg"
                       type="text"
                       placeholder="Email"
+                      defaultValue={user.user.email}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -44,6 +51,7 @@ const Settings = () => {
                       className="form-control form-control-lg"
                       type="password"
                       placeholder="Password"
+                      autoComplete="new-password"
                     />
                   </fieldset>
                   <button className="btn btn-lg btn-primary pull-xs-right">Update Settings</button>


### PR DESCRIPTION
## 작업 내용

https://github.com/nijuy/realworld-PB/commit/25b114926903894be225a6b57ddea96facc1737b : image, username, email 칸을 기존 정보로 채웠습니다

https://github.com/nijuy/realworld-PB/pull/9/commits/d4115781c4010259e85433561989004dc8c2dde9 : `Or click here to logout` 버튼 이벤트를 추가했습니다.

https://github.com/nijuy/realworld-PB/pull/9/commits/d8f15bd6010809da4353e9efc5ff7f39ca4d6be8 : 로그인 하지 않은 상태에서 url 입력으로 /settings 접근 시, 홈 화면으로 이동시킵니다.

https://github.com/nijuy/realworld-PB/pull/9/commits/a30529d30abf297857a4cb34e2aba64793c1de56 : email input type 수정 (text ➡ email)

https://github.com/nijuy/realworld-PB/pull/9/commits/86c9cf9976ba02277d8a198af4b74d081484eb80 : `userApi.modify()` 수정 (axios.put 뒤 제네릭 삭제, 인자 수정, 함수 반환 타입 추가)

https://github.com/nijuy/realworld-PB/pull/9/commits/5ce1b24bdcee8b4a67807712535ee1829ff9e80e : input별 ref 추가

https://github.com/nijuy/realworld-PB/pull/9/commits/55a59ddd0f55a8e59226d9c13a2771ae323645c6 : `update settings` 버튼 이벤트 추가

https://github.com/nijuy/realworld-PB/pull/9/commits/a3161ce9f50c286d6f25734d5498381d4d15f533 : 토큰 갱신 코드 추가, 수정 완료 후 홈 화면 이동

## 기타
* ~~- bio 칸도 기본 값으로 채워야 합니다~~ ➡ 커밋 https://github.com/nijuy/realworld-PB/pull/9/commits/de7f6c888643eb1c15c6efadf79f919f0aa53cce ! 

* 정보 수정 완료 후, **홈 화면이 아니라 유저 페이지로 이동하도록** 수정해야 합니다.

## 실행 화면
|로그인 ❌|로그인 ⭕|
|---|---|
|![test](https://github.com/nijuy/realworld-PB/assets/87255462/c38ab0f8-c2b0-40a8-a2ab-ba71ad824bc9)|![test](https://github.com/nijuy/realworld-PB/assets/87255462/619a8750-d6dc-4193-a80a-1f8345ebc956)|
|url /settings 치면 홈으로 이동|기본값 채워져 있음, 버튼 클릭 시 로그아웃 후 홈으로 이동|

