### PR TITLE
feat(Signup): email input type 변경 / 토큰 갱신 코드 추가 / userApi.join() 수정

### DIFF
--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -25,8 +25,8 @@ const userApi = {
     return response;
   },
 
-  join: (userData: { user: IJoinUserData }) => {
-    const response = Axios.post<IJoinUserData, IGlobalUserData>('/users', userData);
+  join: (userData: { user: IJoinUserData }): Promise<AxiosResponse<IGlobalUserData>> => {
+    const response = Axios.post('/users', userData);
     return response;
   },
 

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -21,8 +21,7 @@ const Signup = () => {
     password: '',
     username: '',
   };
-  const [signupResponseData, setSignupResponseData] =
-    useRecoilState<IGlobalUserData>(currentUserState);
+  const [user, setUser] = useRecoilState<IGlobalUserData>(currentUserState);
   const [signupStatusData, setSignupStatusData] = useState<ISignupError>();
 
   const emailRef = useRef<HTMLInputElement>(null);
@@ -46,7 +45,7 @@ const Signup = () => {
   const join = async (signupData: IJoinUserData) => {
     try {
       const response = await userApi.join({ user: signupData });
-      setSignupResponseData(response.data);
+      setUser(response.data);
       setToken(response.data.user.token);
       updateHeader(response.data.user.token);
     } catch (error) {
@@ -62,10 +61,10 @@ const Signup = () => {
   };
 
   useEffect(() => {
-    if (signupResponseData.user.token !== '') {
+    if (user.user.token !== '') {
       navigate('/');
     }
-  }, [signupResponseData]);
+  }, [user]);
 
   return (
     <>

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -31,18 +31,12 @@ const Signup = () => {
 
   const onClickSignupData = () => {
     if (emailRef.current?.checkValidity()) {
-      if (
-        emailRef.current !== null &&
-        usernameRef.current !== null &&
-        passwordRef.current !== null
-      ) {
-        signupData = {
-          email: emailRef.current.value,
-          username: usernameRef.current.value,
-          password: passwordRef.current.value,
-        };
-        join(signupData);
-      }
+      signupData = {
+        email: emailRef.current.value,
+        username: usernameRef.current!.value,
+        password: passwordRef.current!.value,
+      };
+      join(signupData);
     }
   };
 

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -29,15 +29,20 @@ const Signup = () => {
 
   const navigate = useNavigate();
 
-  const onClickSignupData = (buttonEvent: React.MouseEvent<HTMLButtonElement>) => {
-    buttonEvent.preventDefault();
-    if (emailRef.current !== null && usernameRef.current !== null && passwordRef.current !== null) {
-      signupData = {
-        email: emailRef.current.value,
-        username: usernameRef.current.value,
-        password: passwordRef.current.value,
-      };
-      join(signupData);
+  const onClickSignupData = () => {
+    if (emailRef.current?.checkValidity()) {
+      if (
+        emailRef.current !== null &&
+        usernameRef.current !== null &&
+        passwordRef.current !== null
+      ) {
+        signupData = {
+          email: emailRef.current.value,
+          username: usernameRef.current.value,
+          password: passwordRef.current.value,
+        };
+        join(signupData);
+      }
     }
   };
 
@@ -93,7 +98,7 @@ const Signup = () => {
                     </fieldset>
                     <input
                       className="form-control form-control-lg"
-                      type="text"
+                      type="email"
                       placeholder="Email"
                       ref={emailRef}
                     />

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -8,6 +8,8 @@ import { IError } from '../../types/error.type';
 import Layout from '../layout/Layout';
 import userApi from '../../api/userApi';
 import ErrorPrint from '../ErrorPrint';
+import { setToken } from '../../services/TokenService';
+import { updateHeader } from '../../api/api';
 
 interface ISignupError extends IError {
   signupStatus: boolean;
@@ -44,6 +46,8 @@ const Signup = () => {
     try {
       const response = await userApi.join({ user: signupData });
       setSignupResponseData(response.data);
+      setToken(response.data.user.token);
+      updateHeader(response.data.user.token);
     } catch (error) {
       const signupError = error as AxiosError;
       if (signupError.response !== undefined && signupError.response.data !== null) {

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -62,7 +62,7 @@ const Signup = () => {
   };
 
   useEffect(() => {
-    if (signupResponseData.token !== '') {
+    if (signupResponseData.user.token !== '') {
       navigate('/');
     }
   }, [signupResponseData]);

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -31,8 +31,9 @@ const Signup = () => {
 
   const navigate = useNavigate();
 
-  const onClickSignupData = () => {
+  const onClickSignupData = (buttonEvent: React.MouseEvent<HTMLButtonElement>) => {
     if (emailRef.current?.checkValidity()) {
+      buttonEvent.preventDefault();
       signupData = {
         email: emailRef.current.value,
         username: usernameRef.current!.value,


### PR DESCRIPTION
## 작업 내용
* https://github.com/nijuy/realworld-PB/pull/13/commits/f310bdda2e206237d4e07075c0634911f0895fcc

  * email input type 변경: text ➡ email
  * onClickSigninData 내에서 형식대로 입력 됐는지 확인 (`checkValidity()`)
 
* https://github.com/nijuy/realworld-PB/pull/13/commits/c3473c68e3ec6df5875f00710a0cfb55952ca7e4 : if문 대신 `!` 사용하는 방향으로 수정

* https://github.com/nijuy/realworld-PB/pull/13/commits/c081546a7f242c9e828dbee69ac5d42cd7ee6dac : `userApi.join()` 수정 (axios.post 뒤에 있던 제네릭 삭제, 함수 반환 타입 추가)

* https://github.com/nijuy/realworld-PB/pull/13/commits/a5146828a507061b829d31e0db232dd9404a3cf3 :   api 응답 받은 이후에 토큰 갱신 코드 추가

## 기타
* signin은 email input type 변경 / 토큰 갱신 따로 pr 만들어놓고 signup은 하나에서 다 한 이유

  ➡（⊙ｏ⊙）......... 작업 중에 실시간으로 올리고합치고올리고합치고 하다보니 까먹었네요

@indianaPoly

* 조건 체크가 버튼을 눌렀을 때만 이루어지도록 수정해야 합니다 (지금은 실시간으로 뭐라함)

* `signupResponseData` 를 header, home에서 사용하고 있는 이름처럼 `user`로 변경했으면 합니다. 

  1. 불필요하게 길다는 느낌이 들고
  2. "유저 정보를 갱신한다"라는 의미를 더 잘 드러내는 이름은 `setSignupResponseData(response.data)` 보다 `setUser(response.data)` 인 거 같아요 제 생각에

## 실행 화면
![test](https://github.com/nijuy/realworld-PB/assets/87255462/49847b98-9815-4d49-9c3d-682c632a12b7)
