### PR TITLE
feat(CreateArticle): 글 작성 페이지

### DIFF
--- a/src/api/articlesApi.ts
+++ b/src/api/articlesApi.ts
@@ -1,0 +1,12 @@
+import { IMultipleArticlesResponse, INewArticleRequest } from '../types/articleApi.type';
+import { Axios } from './api';
+
+export const articleApi = {
+  create: (articleData: INewArticleRequest) => {
+    const response = Axios.post('/articles', articleData);
+    return response;
+  },
+  read: () => {},
+  update: () => {},
+  delete: () => {},
+};

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -1,6 +1,17 @@
+import { useEffect } from 'react';
 import Layout from '../layout/Layout';
+import { getToken } from '../../services/TokenService';
+import { useNavigate } from 'react-router-dom';
 
 const CreateArticle = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (getToken() === null) {
+      navigate('/');
+    }
+  }, []);
+
   return (
     <Layout>
       <div className="editor-page">

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -1,10 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Layout from '../layout/Layout';
 import { getToken } from '../../services/TokenService';
 import { useNavigate } from 'react-router-dom';
 
 const CreateArticle = () => {
   const navigate = useNavigate();
+
+  const titleRef = useRef<HTMLInputElement>(null);
+  const descriptionRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+  const tagRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (getToken() === null) {
@@ -25,6 +30,7 @@ const CreateArticle = () => {
                       type="text"
                       className="form-control form-control-lg"
                       placeholder="Article Title"
+                      ref={titleRef}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -32,6 +38,7 @@ const CreateArticle = () => {
                       type="text"
                       className="form-control"
                       placeholder="What's this article about?"
+                      ref={descriptionRef}
                     />
                   </fieldset>
                   <fieldset className="form-group">
@@ -39,10 +46,16 @@ const CreateArticle = () => {
                       className="form-control"
                       rows={8}
                       placeholder="Write your article (in markdown)"
+                      ref={contentRef}
                     ></textarea>
                   </fieldset>
                   <fieldset className="form-group">
-                    <input type="text" className="form-control" placeholder="Enter tags" />
+                    <input
+                      type="text"
+                      className="form-control"
+                      placeholder="Enter tags"
+                      ref={tagRef}
+                    />
                     <div className="tag-list"></div>
                   </fieldset>
                   <button className="btn btn-lg pull-xs-right btn-primary" type="button">

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Layout from '../layout/Layout';
 import { getToken } from '../../services/TokenService';
 import { useNavigate } from 'react-router-dom';
@@ -10,6 +10,21 @@ const CreateArticle = () => {
   const descriptionRef = useRef<HTMLInputElement>(null);
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const tagRef = useRef<HTMLInputElement>(null);
+
+  const [tagList, setTagList] = useState<string[]>([]);
+
+  const addTag = () => {
+    const newTag = tagRef.current?.value || '';
+
+    if (newTag !== '' && !tagList?.includes(newTag)) {
+      setTagList((prevState) => [...prevState!, newTag]);
+      tagRef.current!.value = '';
+    }
+  };
+
+  const removeTag = (removedTag: string) => {
+    setTagList((prevState) => prevState.filter((tag) => tag !== removedTag));
+  };
 
   useEffect(() => {
     if (getToken() === null) {
@@ -50,13 +65,41 @@ const CreateArticle = () => {
                     ></textarea>
                   </fieldset>
                   <fieldset className="form-group">
-                    <input
-                      type="text"
-                      className="form-control"
-                      placeholder="Enter tags"
-                      ref={tagRef}
-                    />
-                    <div className="tag-list"></div>
+                    <div style={{ display: 'flex' }}>
+                      <input
+                        type="text"
+                        className="form-control"
+                        placeholder="Enter tags"
+                        ref={tagRef}
+                      />
+                      <button
+                        style={{
+                          marginLeft: '20px',
+                        }}
+                        className="btn btn-md pull-xs-right btn-primary"
+                        type="button"
+                        onClick={addTag}
+                      >
+                        Add Tag
+                      </button>
+                    </div>
+                    <div className="tag-list">
+                      {tagList &&
+                        tagList.map((tagData, index) => (
+                          <span
+                            key={index}
+                            ng-repeat="tag in $ctrl.article.tagList"
+                            className="tag-default tag-pill ng-binding ng-scope"
+                          >
+                            <i
+                              className="ion-close-round"
+                              ng-click="$ctrl.removeTag(tag)"
+                              onClick={() => removeTag(tagData)}
+                            ></i>
+                            {tagData}
+                          </span>
+                        ))}
+                    </div>
                   </fieldset>
                   <button className="btn btn-lg pull-xs-right btn-primary" type="button">
                     Publish Article

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -4,6 +4,13 @@ import { getToken } from '../../services/TokenService';
 import { useNavigate } from 'react-router-dom';
 import { INewArticleRequest } from '../../types/articleApi.type';
 import { articleApi } from '../../api/articlesApi';
+import { AxiosError } from 'axios';
+import { IError } from '../../types/error.type';
+import ErrorPrint from '../ErrorPrint';
+
+interface IPostError extends IError {
+  postStatus: boolean;
+}
 
 const CreateArticle = () => {
   const navigate = useNavigate();
@@ -14,6 +21,7 @@ const CreateArticle = () => {
   const tagRef = useRef<HTMLInputElement>(null);
 
   const [tagList, setTagList] = useState<string[]>([]);
+  const [postStatusData, setPostStatusData] = useState<IPostError>();
 
   let articleData: INewArticleRequest = {
     article: {
@@ -54,7 +62,14 @@ const CreateArticle = () => {
       await articleApi.create(articleData);
       navigate('/');
     } catch (error) {
-      console.log(error);
+      const postError = error as AxiosError;
+      if (postError.response !== undefined && postError.response.data !== null) {
+        const response = postError.response.data as IError;
+        setPostStatusData({
+          postStatus: false,
+          errors: response.errors,
+        });
+      }
     }
   };
 
@@ -70,6 +85,11 @@ const CreateArticle = () => {
         <div className="container page">
           <div className="row">
             <div className="col-md-10 offset-md-1 col-xs-12">
+              {postStatusData && !postStatusData.postStatus && (
+                <ul className="error-messages" ng-show="$ctrl.errors">
+                  <ErrorPrint errors={postStatusData.errors} />
+                </ul>
+              )}
               <form>
                 <fieldset>
                   <fieldset className="form-group">

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import Layout from '../layout/Layout';
 import { getToken } from '../../services/TokenService';
 import { useNavigate } from 'react-router-dom';
+import { INewArticleRequest } from '../../types/articleApi.type';
+import { articleApi } from '../../api/articlesApi';
 
 const CreateArticle = () => {
   const navigate = useNavigate();
@@ -12,6 +14,15 @@ const CreateArticle = () => {
   const tagRef = useRef<HTMLInputElement>(null);
 
   const [tagList, setTagList] = useState<string[]>([]);
+
+  let articleData: INewArticleRequest = {
+    article: {
+      title: '',
+      description: '',
+      body: '',
+      tagList: [],
+    },
+  };
 
   const addTag = () => {
     const newTag = tagRef.current?.value || '';
@@ -24,6 +35,27 @@ const CreateArticle = () => {
 
   const removeTag = (removedTag: string) => {
     setTagList((prevState) => prevState.filter((tag) => tag !== removedTag));
+  };
+
+  const onSubmitArticle = () => {
+    articleData = {
+      article: {
+        title: titleRef.current!.value,
+        description: descriptionRef.current!.value,
+        body: bodyRef.current!.value,
+        tagList: tagList,
+      },
+    };
+    createArticle(articleData);
+  };
+
+  const createArticle = async (articleData: INewArticleRequest) => {
+    try {
+      await articleApi.create(articleData);
+      navigate('/');
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   useEffect(() => {
@@ -101,7 +133,11 @@ const CreateArticle = () => {
                         ))}
                     </div>
                   </fieldset>
-                  <button className="btn btn-lg pull-xs-right btn-primary" type="button">
+                  <button
+                    className="btn btn-lg pull-xs-right btn-primary"
+                    type="button"
+                    onClick={onSubmitArticle}
+                  >
                     Publish Article
                   </button>
                 </fieldset>

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -35,10 +35,18 @@ const CreateArticle = () => {
   const addTag = () => {
     const newTag = tagRef.current?.value || '';
 
-    if (newTag !== '' && !tagList?.includes(newTag)) {
-      setTagList((prevState) => [...prevState!, newTag]);
-      tagRef.current!.value = '';
+    if (newTag === '') {
+      alert('태그를 입력해주세요');
+      return;
     }
+
+    if (tagList.includes(newTag)) {
+      alert('이미 추가된 태그입니다');
+      return;
+    }
+
+    setTagList((prevState) => [...prevState!, newTag]);
+    tagRef.current!.value = '';
   };
 
   const removeTag = (removedTag: string) => {

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -67,8 +67,8 @@ const CreateArticle = () => {
 
   const createArticle = async (articleData: INewArticleRequest) => {
     try {
-      await articleApi.create(articleData);
-      navigate('/');
+      const response = await articleApi.create(articleData);
+      navigate(`/article/${response.data.article.slug}`);
     } catch (error) {
       const postError = error as AxiosError;
       if (postError.response !== undefined && postError.response.data !== null) {

--- a/src/components/pages/CreateArticle.tsx
+++ b/src/components/pages/CreateArticle.tsx
@@ -8,7 +8,7 @@ const CreateArticle = () => {
 
   const titleRef = useRef<HTMLInputElement>(null);
   const descriptionRef = useRef<HTMLInputElement>(null);
-  const contentRef = useRef<HTMLTextAreaElement>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
   const tagRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -46,7 +46,7 @@ const CreateArticle = () => {
                       className="form-control"
                       rows={8}
                       placeholder="Write your article (in markdown)"
-                      ref={contentRef}
+                      ref={bodyRef}
                     ></textarea>
                   </fieldset>
                   <fieldset className="form-group">

--- a/src/types/articleApi.type.ts
+++ b/src/types/articleApi.type.ts
@@ -1,0 +1,45 @@
+/**
+ * @CRUD post
+ * @ACTION createArticle
+ */
+export interface INewArticleRequest {
+  article: {
+    title: string;
+    description: string;
+    body: string;
+    tagList: string[];
+  };
+}
+
+/**
+ * @CRUD get
+ * @Action getArticleData
+ */
+export interface ISingleArticleResponse {
+  article: {
+    slug: string;
+    title: string;
+    description: string;
+    body: string;
+    tagList: string[];
+    createdAt: string;
+    updatedAt: string;
+    favorited: boolean;
+    favoritesCount: number;
+    author: {
+      username: string;
+      bio: string;
+      image: string;
+      following: boolean;
+    };
+  };
+}
+
+/**
+ * @CRUD get
+ * @Action getFeedData
+ */
+export interface IMultipleArticlesResponse {
+  articles: ISingleArticleResponse[];
+  articlesCount: number;
+}


### PR DESCRIPTION
## 작업 내용
https://github.com/nijuy/realworld-PB/pull/14/commits/75b72846180882c9f6111a3e1ecedaabf3900dc7 : 비로그인 상태에서 /editor 쳐서 접근 시 홈으로 보내버림

https://github.com/nijuy/realworld-PB/pull/14/commits/4dc12f270ec9177e90902eeefe1be95ab297b552 : article 1개 관련 타입 정의, 이름은 [api 문서](https://api.realworld.io/api-docs/) 내 모델명 사용함

https://github.com/nijuy/realworld-PB/pull/14/commits/efd1fb98c3e52b4271b03a0c0876d2fc4b188eb5 : articleApi.create() 추가

https://github.com/nijuy/realworld-PB/pull/14/commits/3a83cff69bfd2f130c9a742b77e0fbcfd0c3605c : input별 ref 추가

https://github.com/nijuy/realworld-PB/pull/14/commits/cf8aa8cf05e7f4d231f8921911ebc17094d34152 : 태그 생성/삭제 기능 추가 (**데모 사이트와 달라진 부분**)

https://github.com/nijuy/realworld-PB/pull/14/commits/8c2627872448883316c9c3473a8366cf261b3485 : `Publish Article` 버튼 이벤트 추가

https://github.com/nijuy/realworld-PB/pull/14/commits/4fce6d99d3621e57862cead0eaacd6b522b85112 : 글 작성 실패 시 에러 출력 (글 제목 중복, 빈 내용 존재 등)

## 기타
@indianaPoly 

* 나중에 다른 타입명도 모델명 따라가도록 수정하면 좋을 거 같아요

* 중복 태그 안된다고 문구를 추가하거나 / 중복 태그를 추가하려고 할 경우, alert 띄우는 건 어떠세여

## 실행 화면
|로그인 ❌|로그인 ⭕|
|---|---|
|![test2](https://github.com/nijuy/realworld-PB/assets/87255462/5fd3978d-32b7-4366-a379-4d0f98e56f6c)|![test1](https://github.com/nijuy/realworld-PB/assets/87255462/0967f4e5-4972-4854-9a87-5729a4e49023)|

* 태그 생성/삭제 기능 (생성, 중복 태그 생성 불가, 삭제)
  <img src="https://github.com/nijuy/realworld-PB/assets/87255462/8d5c4be4-da7d-4959-a573-2a829cb3e739" width="400" />

* 글 작성
  💥 아직 home, profile 화면이 완성되지 않아 아래 코드처럼 response.data를 콘솔에 찍어본 결과
  ![image](https://github.com/nijuy/realworld-PB/assets/87255462/98e58e66-aa6c-471d-89d8-980adac992a7)


* 에러 출력
  (기존 글과 제목 동일하면 생성 불가, title/description/body 빈 칸 불가)
  ![test](https://github.com/nijuy/realworld-PB/assets/87255462/b460a400-e789-482c-9547-618758d7e4aa)

