### PR TITLE
feat(Home): Home 페이지 Tag Feed 추가 / 피드 가시성 제어 / 페이지 버튼 스타일 적용

### DIFF
--- a/src/api/articlesApi.ts
+++ b/src/api/articlesApi.ts
@@ -61,7 +61,10 @@ export const feedApi = {
     const response = Axios.get<IMultipleArticlesResponse>(
       `/articles?${qs.stringify({ limit: 10, offset, tag, author, favorited })}`,
     );
-
+    return response;
+  },
+  getFollowingFeed: (offset: number): Promise<AxiosResponse<IMultipleArticlesResponse>> => {
+    const response = Axios.get(`/articles/feed?${qs.stringify({ limit: 10, offset })}`);
     return response;
   },
 };

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -1,4 +1,5 @@
 import { IArticle } from '../types/articleApi.type';
+import FavoriteButton from './FavoriteButton';
 
 const ArticlePreview = ({ article }: { article: IArticle }) => {
   const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
@@ -17,9 +18,7 @@ const ArticlePreview = ({ article }: { article: IArticle }) => {
             {new Date(article.createdAt).toLocaleDateString('en-US', dateOptions)}
           </span>
         </div>
-        <button className="btn btn-outline-primary btn-sm pull-xs-right">
-          <i className="ion-heart"></i> {article.favoritesCount}
-        </button>
+        <FavoriteButton article={article} />
       </div>
       <a href="" className="preview-link">
         <h1>{article.title}</h1>

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -1,0 +1,40 @@
+import { IArticle } from '../types/articleApi.type';
+
+const ArticlePreview = ({ article }: { article: IArticle }) => {
+  const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+
+  return (
+    <div className="article-preview">
+      <div className="article-meta">
+        <a href="profile.html">
+          <img src={article.author.image} />
+        </a>
+        <div className="info">
+          <a href="" className="author">
+            {article.author.username}
+          </a>
+          <span className="date">
+            {new Date(article.createdAt).toLocaleDateString('en-US', dateOptions)}
+          </span>
+        </div>
+        <button className="btn btn-outline-primary btn-sm pull-xs-right">
+          <i className="ion-heart"></i> {article.favoritesCount}
+        </button>
+      </div>
+      <a href="" className="preview-link">
+        <h1>{article.title}</h1>
+        <p>{article.description}</p>
+        <span>Read more...</span>
+        <ul className="tag-list">
+          {article.tagList.map((tag, index) => (
+            <li key={index} className="tag-default tag-pill tag-outline">
+              {tag}
+            </li>
+          ))}
+        </ul>
+      </a>
+    </div>
+  );
+};
+
+export default ArticlePreview;

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -4,11 +4,11 @@ import { useQuery } from '@tanstack/react-query';
 import { feedApi } from '../../api/articlesApi';
 import { useRecoilValue } from 'recoil';
 import { currentUserState } from '../../recoil/atom/currentUserData';
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 const Home = () => {
   const user = useRecoilValue(currentUserState);
-  let offset = 0;
+  const [offset, setOffset] = useState(0);
 
   const { isLoading: tagIsLoading, data: tagData } = useQuery({
     queryKey: ['tags'],
@@ -43,10 +43,15 @@ const Home = () => {
   const pageButtonList = () => {
     const buttonCount = feedData.articlesCount / 10 + 1;
     const buttonList: React.ReactNode[] = [];
+    const currentPage = (offset + 10) / 10;
 
     for (let i = 1; i <= buttonCount; i++) {
       buttonList.push(
-        <li key={i} className="page-item" onClick={onClickPageButton}>
+        <li
+          key={i}
+          className={`page-item ${currentPage === i ? 'active' : ''}`}
+          onClick={onClickPageButton}
+        >
           <a className="page-link" href="">
             {i}
           </a>
@@ -59,13 +64,12 @@ const Home = () => {
 
   const onClickPageButton = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    offset = e.target.innerText * 10 - 10;
-    refetch();
+    setOffset(e.target.innerText * 10 - 10);
   };
 
   useEffect(() => {
     refetch();
-  }, [user]);
+  }, [user, offset]);
 
   return (
     <Layout>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -63,12 +63,15 @@ const Home = () => {
     },
   });
 
-  const { data: tagFeedData, refetch: tagFeedRefetch } = useQuery({
+  const {
+    isLoading: tagTabIsLoading,
+    data: tagFeedData,
+    refetch: tagTabRefetch,
+  } = useQuery({
     queryKey: ['tagArticles'],
     queryFn: async () => {
       try {
-        const response = await feedApi.getFeed({ tag: currentTag });
-        console.log(response.data);
+        const response = await feedApi.getFeed({ offset: offset, tag: currentTag });
         return response.data;
       } catch (error) {
         console.log(error);
@@ -103,26 +106,25 @@ const Home = () => {
 
   const onClickTab = (anchorEvent: React.MouseEvent<HTMLAnchorElement>) => {
     setCurrentFeed(anchorEvent.target.id);
+    setCurrentTag('');
     setOffset(0);
   };
 
   const onClickTag = (anchorEvent: React.MouseEvent<HTMLAnchorElement>) => {
+    setCurrentFeed('tag');
     setCurrentTag(anchorEvent.target.innerText);
+    setOffset(0);
   };
 
   useEffect(() => {
     if (currentFeed === 'following') {
       myTabRefetch();
-    } else {
+    } else if (currentFeed === 'global') {
       globalTabRefetch();
+    } else {
+      tagTabRefetch();
     }
-  }, [user, offset]);
-
-  useEffect(() => {
-    if (currentTag !== '') {
-      tagFeedRefetch();
-    }
-  }, [currentTag]);
+  }, [user, currentTag, offset]);
 
   return (
     <Layout>
@@ -159,6 +161,14 @@ const Home = () => {
                       Global Feed
                     </a>
                   </li>
+
+                  {currentTag !== '' && (
+                    <li className="nav-item">
+                      <a className="nav-link active ng-binding">
+                        <i className="ion-pound"></i> {currentTag}
+                      </a>
+                    </li>
+                  )}
                 </ul>
               </div>
 
@@ -193,6 +203,24 @@ const Home = () => {
                         <ul className="pagination">
                           {pageButtonList(myArticlesData?.articlesCount)}
                         </ul>
+                      </ul>
+                    </nav>
+                  </>
+                ))}
+
+              {currentFeed === 'tag' &&
+                (tagTabIsLoading ? (
+                  <div className="article-preview">Loading articles...</div>
+                ) : !tagFeedData?.articlesCount ? (
+                  <div className="article-preview">No articles are here... yet.</div>
+                ) : (
+                  <>
+                    {tagFeedData?.articles.map((article, index) => (
+                      <ArticlePreview key={index} article={article} />
+                    ))}
+                    <nav>
+                      <ul className="pagination">
+                        <ul className="pagination">{pageButtonList(tagFeedData?.articlesCount)}</ul>
                       </ul>
                     </nav>
                   </>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -12,6 +12,7 @@ const Home = () => {
 
   const [offset, setOffset] = useState(0);
   const [isMyArticles, setIsMyArticles] = useState(false);
+  const [currentTag, setCurrentTag] = useState('');
 
   const { isLoading: tagIsLoading, data: tagData } = useQuery({
     queryKey: ['tags'],
@@ -60,6 +61,20 @@ const Home = () => {
     },
   });
 
+  const { data: tagFeedData, refetch: tagFeedRefetch } = useQuery({
+    queryKey: ['tagArticles'],
+    queryFn: async () => {
+      try {
+        const response = await feedApi.getFeed({ tag: currentTag });
+        console.log(response.data);
+        return response.data;
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    enabled: false,
+  });
+
   const pageButtonList = (articlesCount: number) => {
     const buttonCount = articlesCount / 10 + 1;
     const buttonList: React.ReactNode[] = [];
@@ -89,6 +104,10 @@ const Home = () => {
     setOffset(0);
   };
 
+  const onClickTag = (anchorEvent: React.MouseEvent<HTMLAnchorElement>) => {
+    setCurrentTag(anchorEvent.target.innerText);
+  };
+
   useEffect(() => {
     if (isMyArticles) {
       myTabRefetch();
@@ -96,6 +115,12 @@ const Home = () => {
       globalTabRefetch();
     }
   }, [user, offset]);
+
+  useEffect(() => {
+    if (currentTag !== '') {
+      tagFeedRefetch();
+    }
+  }, [currentTag]);
 
   return (
     <Layout>
@@ -177,7 +202,7 @@ const Home = () => {
                   <div className="tag-list">
                     {tagData!.map((tagData, index) => {
                       return (
-                        <a key={index} href="" className="tag-pill tag-default">
+                        <a key={index} className="tag-pill tag-default" onClick={onClickTag}>
                           {tagData}
                         </a>
                       );

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -7,11 +7,13 @@ import { currentUserState } from '../../recoil/atom/currentUserData';
 import { useState, useEffect } from 'react';
 import ArticlePreview from '../ArticlePreview';
 
+type FeedType = 'following' | 'global' | 'tag';
+
 const Home = () => {
   const user = useRecoilValue(currentUserState);
 
   const [offset, setOffset] = useState(0);
-  const [isMyArticles, setIsMyArticles] = useState(false);
+  const [currentFeed, setCurrentFeed] = useState<FeedType>('global');
   const [currentTag, setCurrentTag] = useState('');
 
   const { isLoading: tagIsLoading, data: tagData } = useQuery({
@@ -99,8 +101,8 @@ const Home = () => {
     setOffset(e.target.innerText * 10 - 10);
   };
 
-  const onClickTab = () => {
-    setIsMyArticles(!isMyArticles);
+  const onClickTab = (anchorEvent: React.MouseEvent<HTMLAnchorElement>) => {
+    setCurrentFeed(anchorEvent.target.id);
     setOffset(0);
   };
 
@@ -109,7 +111,7 @@ const Home = () => {
   };
 
   useEffect(() => {
-    if (isMyArticles) {
+    if (currentFeed === 'following') {
       myTabRefetch();
     } else {
       globalTabRefetch();
@@ -140,7 +142,8 @@ const Home = () => {
                   {user.user.token && (
                     <li className="nav-item">
                       <a
-                        className={`nav-link${isMyArticles ? ' active' : ''}`}
+                        className={`nav-link${currentFeed === 'following' ? ' active' : ''}`}
+                        id="following"
                         onClick={onClickTab}
                       >
                         Your Feed
@@ -148,14 +151,18 @@ const Home = () => {
                     </li>
                   )}
                   <li className="nav-item">
-                    <a className={`nav-link${!isMyArticles ? ' active' : ''}`} onClick={onClickTab}>
+                    <a
+                      className={`nav-link${currentFeed === 'global' ? ' active' : ''}`}
+                      id="global"
+                      onClick={onClickTab}
+                    >
                       Global Feed
                     </a>
                   </li>
                 </ul>
               </div>
 
-              {!isMyArticles &&
+              {currentFeed === 'global' &&
                 (globalTabIsLoading ? (
                   <div> loading ... </div>
                 ) : (
@@ -171,7 +178,7 @@ const Home = () => {
                   </>
                 ))}
 
-              {isMyArticles &&
+              {currentFeed === 'following' &&
                 (myTabIsLoading ? (
                   <div className="article-preview">Loading articles...</div>
                 ) : !myArticlesData?.articlesCount ? (

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -5,6 +5,7 @@ import { feedApi } from '../../api/articlesApi';
 import { useRecoilValue } from 'recoil';
 import { currentUserState } from '../../recoil/atom/currentUserData';
 import { useState, useEffect } from 'react';
+import ArticlePreview from '../ArticlePreview';
 
 const Home = () => {
   const user = useRecoilValue(currentUserState);
@@ -135,34 +136,7 @@ const Home = () => {
                 ) : (
                   <>
                     {globalArticlesData?.articles.map((article, index) => (
-                      <div key={index} className="article-preview">
-                        <div className="article-meta">
-                          <a href="profile.html">
-                            <img src={article.author.image} />
-                          </a>
-                          <div className="info">
-                            <a href="" className="author">
-                              {article.author.username}
-                            </a>
-                            <span className="date">January 20th</span>
-                          </div>
-                          <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                            <i className="ion-heart"></i> {article.favoritesCount}
-                          </button>
-                        </div>
-                        <a href="" className="preview-link">
-                          <h1>{article.title}</h1>
-                          <p>{article.description}</p>
-                          <span>Read more...</span>
-                          <ul className="tag-list">
-                            {article.tagList.map((tag, index) => (
-                              <li key={index} className="tag-default tag-pill tag-outline">
-                                {tag}
-                              </li>
-                            ))}
-                          </ul>
-                        </a>
-                      </div>
+                      <ArticlePreview key={index} article={article} />
                     ))}
                     <nav>
                       <ul className="pagination">
@@ -180,34 +154,7 @@ const Home = () => {
                 ) : (
                   <>
                     {myArticlesData?.articles.map((article, index) => (
-                      <div key={index} className="article-preview">
-                        <div className="article-meta">
-                          <a href="profile.html">
-                            <img src={article.author.image} />
-                          </a>
-                          <div className="info">
-                            <a href="" className="author">
-                              {article.author.username}
-                            </a>
-                            <span className="date">January 20th</span>
-                          </div>
-                          <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                            <i className="ion-heart"></i> {article.favoritesCount}
-                          </button>
-                        </div>
-                        <a href="" className="preview-link">
-                          <h1>{article.title}</h1>
-                          <p>{article.description}</p>
-                          <span>Read more...</span>
-                          <ul className="tag-list">
-                            {article.tagList.map((tag, index) => (
-                              <li key={index} className="tag-default tag-pill tag-outline">
-                                {tag}
-                              </li>
-                            ))}
-                          </ul>
-                        </a>
-                      </div>
+                      <ArticlePreview key={index} article={article} />
                     ))}
                     <nav>
                       <ul className="pagination">

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -22,7 +22,6 @@ const Home = () => {
         console.log(error);
       }
     },
-    staleTime: Infinity,
   });
 
   const {

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -52,9 +52,7 @@ const Home = () => {
           className={`page-item ${currentPage === i ? 'active' : ''}`}
           onClick={onClickPageButton}
         >
-          <a className="page-link" href="">
-            {i}
-          </a>
+          <a className="page-link">{i}</a>
         </li>,
       );
     }
@@ -62,8 +60,7 @@ const Home = () => {
     return buttonList;
   };
 
-  const onClickPageButton = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const onClickPageButton = (e: React.MouseEvent<HTMLLIElement>) => {
     setOffset(e.target.innerText * 10 - 10);
   };
 


### PR DESCRIPTION
## 작업 내용
https://github.com/nijuy/realworld-PB/pull/26/commits/e7c530e65b52bbc62ebe70e98677f1e8b360c014
  * 변수 `offset`을 state로 변경
  * 페이지 버튼 (li 태그) className으로 스타일 적용

https://github.com/nijuy/realworld-PB/pull/26/commits/af66910e9ecca5f73f162fa52b76609b1e5cb79c : 페이지 버튼 (li 태그)의 onClick 이벤트인 `onClickPageButton` 함수 파라미터 타입을 수정했습니다

https://github.com/nijuy/realworld-PB/pull/26/commits/31e2594074d36140fd1fa6eeb5f0a025c0035141 : 내가 팔로우 한 사용자의 글을 가져오는 `getFollowingFeed()`를 추가했습니다 (your feed용)

https://github.com/nijuy/realworld-PB/pull/26/commits/0a35ed4ccd8ebeaed4951def63fb7c84e554eae4
  * your feed 탭의 글을 가져오는 `useQuery`문을 추가했습니다
  * global feed 탭 관련 변수명을 수정했습니다
  * 페이지 버튼을 생성하는 `pageButtonList()` 을 수정했습니다
  *  boolean 타입 변수 `isMyArticles` 를 통해 global feed / your feed의 가시성을 제어합니다

https://github.com/nijuy/realworld-PB/pull/26/commits/3919ec2be7768b85379b9b8f78c341cf775af88b ~ https://github.com/nijuy/realworld-PB/pull/26/commits/23a248223782f4f44820541af5219317c800c113 : 글 목록을 보여주는 컴포넌트 `ArticlePreview` 를 만들고 적용했습니다.

https://github.com/nijuy/realworld-PB/pull/26/commits/005fa0e9127d0ef5b0d6602d69d5ce418da3030b : Popular Tag 내 태그를 클릭했을 때, 해당 태그가 포함된 글을 가져오는 `useQuery`문을 추가했습니다

https://github.com/nijuy/realworld-PB/pull/26/commits/ef9f26fb690c52ce6a346263d0abe1cb36fcd713 : 탭 3개 중 현재 보고있는 피드를 표시하기 위해, `isMyArticles`를 `currentFeed`로 수정했습니다

https://github.com/nijuy/realworld-PB/pull/26/commits/412bbd9a721fc4f980b37580f9b3282eea39bf5e : tag feed를 화면에 추가했습니다 (콘솔에서만 확인 중이었음)

## 기타
* `ArticlePreview` 컴포넌트에서, 하나의 글을 클릭하면 `/article/slug`로 넘어가야 합니다
* your feed, global feed, popular tag 목록 내 태그에 사용중인 a 태그 커서 모양 바꾸면 좋을 거 같아요
* 좋아요 버튼 위치 수정 예정 ^^............

## 실행 화면
![test](https://github.com/nijuy/realworld-PB/assets/87255462/d815f1ef-5abd-4d42-be8d-da9ac902dad3)

