### PR TITLE
refactor: 리팩토링 작업 진행

### DIFF
--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -24,12 +24,12 @@ const FavoriteButton = ({
 
     if (favorited) {
       setFavoriteCount(favoriteCount - 1);
-      setFavorited(false);
       await articleApi.unfavorite(article.slug);
+      setFavorited(false);
     } else {
       setFavoriteCount(favoriteCount + 1);
-      setFavorited(true);
       await articleApi.favorite(article.slug);
+      setFavorited(true);
     }
   };
 

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,5 @@
+const Loading = ({ textValue }: { textValue: string }) => {
+  return <div className="article-preview">Loading {textValue}...</div>;
+};
+
+export default Loading;

--- a/src/pages/Article.tsx
+++ b/src/pages/Article.tsx
@@ -21,7 +21,7 @@ const Article = () => {
   const commentRef = useRef<HTMLTextAreaElement>(null);
 
   const { data: articleData, isSuccess: articleIsSuccess } = useQuery({
-    queryKey: ['article'],
+    queryKey: ['article', slug],
     queryFn: async () => {
       try {
         if (slug !== undefined) {

--- a/src/pages/Article.tsx
+++ b/src/pages/Article.tsx
@@ -39,7 +39,7 @@ const Article = () => {
     refetch,
     isSuccess: commentIsSuccess,
   } = useQuery({
-    queryKey: ['comment'],
+    queryKey: ['comment', slug],
     queryFn: async () => {
       try {
         if (slug !== undefined) {

--- a/src/pages/CreateArticle.tsx
+++ b/src/pages/CreateArticle.tsx
@@ -5,12 +5,8 @@ import { useNavigate } from 'react-router-dom';
 import { INewArticleRequest } from '../types/articleApi.type';
 import { articleApi } from '../api/articlesApi';
 import { AxiosError } from 'axios';
-import { IError } from '../types/error.type';
+import { IError, IPostError } from '../types/error.type';
 import ErrorPrint from '../components/ErrorPrint';
-
-interface IPostError extends IError {
-  postStatus: boolean;
-}
 
 const CreateArticle = () => {
   const navigate = useNavigate();

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { currentUserState } from '../recoil/atom/currentUserData';
 import { useState, useEffect } from 'react';
 import ArticlePreview from '../components/ArticlePreview';
+import Loading from '../components/Loading';
 
 type FeedType = 'following' | 'global' | 'tag';
 
@@ -194,15 +195,13 @@ const Home = () => {
 
               {currentFeed === 'global' &&
                 (globalTabIsLoading ? (
-                  <div className="article-preview">Loading articles...</div>
+                  <Loading textValue="articles" />
                 ) : (
                   <>
                     {globalArticlesData?.articles.map((article, index) => (
                       <ArticlePreview key={index} article={article} />
                     ))}
-                    {globalTabIsRefetching && (
-                      <div className="article-preview">Loading articles...</div>
-                    )}
+                    {globalTabIsRefetching && <Loading textValue="articles" />}
                     <nav>
                       <ul className="pagination">
                         {pageButtonList(globalArticlesData?.articlesCount as number)}
@@ -213,7 +212,7 @@ const Home = () => {
 
               {currentFeed === 'following' &&
                 (myTabIsLoading ? (
-                  <div className="article-preview">Loading articles...</div>
+                  <Loading textValue="articles" />
                 ) : !myArticlesData?.articlesCount ? (
                   <div className="article-preview">No articles are here... yet.</div>
                 ) : (
@@ -221,9 +220,7 @@ const Home = () => {
                     {myArticlesData?.articles.map((article, index) => (
                       <ArticlePreview key={index} article={article} />
                     ))}
-                    {myTabIsRefetching && (
-                      <div className="article-preview">Loading articles...</div>
-                    )}
+                    {myTabIsRefetching && <Loading textValue="articles" />}
                     <nav>
                       <ul className="pagination">
                         <ul className="pagination">
@@ -236,7 +233,7 @@ const Home = () => {
 
               {currentFeed === 'tag' &&
                 (tagTabIsLoading ? (
-                  <div className="article-preview">Loading articles...</div>
+                  <Loading textValue="articles" />
                 ) : !tagFeedData?.articlesCount ? (
                   <div className="article-preview">No articles are here... yet.</div>
                 ) : (
@@ -244,9 +241,7 @@ const Home = () => {
                     {tagFeedData?.articles.map((article, index) => (
                       <ArticlePreview key={index} article={article} />
                     ))}
-                    {tagTabIsRefetching && (
-                      <div className="article-preview">Loading articles...</div>
-                    )}
+                    {tagTabIsRefetching && <Loading textValue="articles" />}
                     <nav>
                       <ul className="pagination">
                         <ul className="pagination">{pageButtonList(tagFeedData?.articlesCount)}</ul>
@@ -261,7 +256,7 @@ const Home = () => {
                 <p>Popular Tags</p>
 
                 {tagIsLoading ? (
-                  <div className="article-preview">Loading tags...</div>
+                  <Loading textValue="tags" />
                 ) : (
                   <div className="tag-list">
                     {tagData!.map((tagData, index) => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -72,7 +72,7 @@ const Home = () => {
     data: tagFeedData,
     refetch: tagTabRefetch,
   } = useQuery({
-    queryKey: ['tagArticles'],
+    queryKey: ['tagArticles', currentTag],
     queryFn: async () => {
       try {
         const response = await feedApi.getFeed({ offset: offset, tag: currentTag });

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -9,6 +9,7 @@ import { useQuery } from '@tanstack/react-query';
 import { feedApi } from '../api/articlesApi';
 import ArticlePreview from '../components/ArticlePreview';
 import FollowButton from '../components/FollowButton';
+import Loading from '../components/Loading';
 
 const Profile = () => {
   const user = useRecoilValue(currentUserState);
@@ -178,7 +179,7 @@ const Profile = () => {
 
               {isMyArticles &&
                 (myTabIsLoading ? (
-                  <div className="article-preview">Loading articles...</div>
+                  <Loading textValue="articles" />
                 ) : !myArticlesData?.articlesCount ? (
                   <div className="article-preview">No articles are here... yet.</div>
                 ) : (
@@ -186,9 +187,7 @@ const Profile = () => {
                     {myArticlesData!.articles.map((articleData, index) => (
                       <ArticlePreview key={index} article={articleData} />
                     ))}
-                    {myTabIsRefetching && (
-                      <div className="article-preview">Loading articles...</div>
-                    )}
+                    {myTabIsRefetching && <Loading textValue="articles" />}
                     <nav>
                       <ul className="pagination">{pageButtonList(myArticlesData.articlesCount)}</ul>
                     </nav>
@@ -197,7 +196,7 @@ const Profile = () => {
 
               {!isMyArticles &&
                 (favoritedTabIsLoading ? (
-                  <div className="article-preview">Loading articles...</div>
+                  <Loading textValue="articles" />
                 ) : !favoritedArticlesData?.articlesCount ? (
                   <div className="article-preview">No articles are here... yet.</div>
                 ) : (
@@ -205,9 +204,7 @@ const Profile = () => {
                     {favoritedArticlesData!.articles.map((articleData, index) => (
                       <ArticlePreview key={index} article={articleData} />
                     ))}
-                    {favoritedTabIsRefetching && (
-                      <div className="article-preview">Loading articles...</div>
-                    )}
+                    {favoritedTabIsRefetching && <Loading textValue="articles" />}
                     <nav>
                       <ul className="pagination">
                         {pageButtonList(favoritedArticlesData.articlesCount)}

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -3,17 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { userApi } from '../api/userApi';
 import { ILoginUserData } from '../types/userApi.type';
 import { AxiosError } from 'axios';
-import { IError } from '../types/error.type';
+import { IError, ISigninError } from '../types/error.type';
 import ErrorPrint from '../components/ErrorPrint';
 import Layout from '../components/layout/Layout';
 import { useRecoilState } from 'recoil';
 import { currentUserState } from '../recoil/atom/currentUserData';
 import { getToken, setToken } from '../services/tokenService';
 import { updateHeader } from '../api/api';
-
-interface ISigninError extends IError {
-  signinStatus: boolean;
-}
 
 const Signin = () => {
   const [_, setUser] = useRecoilState(currentUserState);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -4,16 +4,12 @@ import { useRecoilState } from 'recoil';
 import { currentUserState } from '../recoil/atom/currentUserData';
 import { IJoinUserData } from '../types/userApi.type';
 import { AxiosError } from 'axios';
-import { IError } from '../types/error.type';
+import { IError, ISignupError } from '../types/error.type';
 import Layout from '../components/layout/Layout';
 import { userApi } from '../api/userApi';
 import ErrorPrint from '../components/ErrorPrint';
 import { getToken, setToken } from '../services/tokenService';
 import { updateHeader } from '../api/api';
-
-interface ISignupError extends IError {
-  signupStatus: boolean;
-}
 
 const Signup = () => {
   const [_, setUser] = useRecoilState(currentUserState);

--- a/src/types/error.type.ts
+++ b/src/types/error.type.ts
@@ -3,3 +3,15 @@ export interface IError {
     [key: string]: string[];
   };
 }
+
+export interface ISignupError extends IError {
+  signupStatus: boolean;
+}
+
+export interface ISigninError extends IError {
+  signinStatus: boolean;
+}
+
+export interface IPostError extends IError {
+  postStatus: boolean;
+}


### PR DESCRIPTION
## 작업 내용
✨ 노션 `폴리보리의 (아마도) 신나는 리팩토링` 참고<br/><br/>

* `useQuery` queryKey 배열에 요소를 추가했습니다
  
  * `Article` : Article, Comment 가져올 때 `slug` (글마다 가지는 고유값) 추가
  * `Home` : 특정 태그가 포함된 글 가져올 때 `currentTag` (현재 선택된 태그) 추가

* 로딩 문구를 별도의 컴포넌트로 뺐습니다 (`Loading`)
* 좋아요 버튼 클릭 시, api 호출이 끝난 후에 버튼 상태를 변경하도록 코드 순서를 바꿨습니다
* `IPostError` `ISigninError` `ISignupError` 의 정의 위치를 컴포넌트에서 타입 파일로 바꿨습니다

## 실행 화면
(1) 게시글 로딩 시 이전 글이 노출되지 않게 함
![logintest2](https://github.com/nijuy/realworld-PB/assets/87255462/5307e573-c6f6-452f-a489-b5dd02101bf2)

(2) 태그를 바꿀 때 로딩문구만 노출되도록 함
![tagtest](https://github.com/nijuy/realworld-PB/assets/87255462/76add613-f44f-4c9e-a072-e576bdacc5d9)
